### PR TITLE
Update linting scripts in package.json removed the redundant code

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "jest",
     "lint": "npm run lint:js && npm run lint:html",
     "lint:js": "eslint '*.js'",
-    "lint:fix": "eslint '*.js' --fix",
+    "lint:js-fix": "eslint '*.js' --fix",
     "lint:html": "htmlhint index.html",
     "lint:all": "npm run lint"
   },

--- a/package.json
+++ b/package.json
@@ -3,18 +3,19 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  
   "scripts": {
     "test": "jest",
-    "lint": "eslint '*.js'",
+    "lint": "npm run lint:js && npm run lint:html",
+    "lint:js": "eslint '*.js'",
     "lint:fix": "eslint '*.js' --fix",
     "lint:html": "htmlhint index.html",
-    "lint:all": "npm run lint && npm run lint:html"
+    "lint:all": "npm run lint"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^5.1.0"
   },
   "devDependencies": {
     "eslint": "^8.57.1",


### PR DESCRIPTION
What I changed and why:

1. Created `lint:js`: I moved the specific JavaScript check to its own command `lint:js`.

2. Updated `lint`: The main lint command now chains them together `lint:js && lint:html`. This means when the GitHub Action runs `npm run lint`, it will now check both.

3. Updated `lint:all`: I just pointed this to `npm run lint` so it does the same thing, keeping it as an alias in case anyone is used to typing it.

4. Remove `express` from `dependencies` since it is already in `devDependencies` 